### PR TITLE
Turbo mode overhaul: 25MHz, expansion card DMA, bus safety

### DIFF
--- a/CHANGELOG-8b70279-to-025ee20.md
+++ b/CHANGELOG-8b70279-to-025ee20.md
@@ -1,0 +1,302 @@
+# SF2000 Firmware Changelog: 8b70279 to 025ee20
+
+Analysis of 19 commits made between commit 8b70279 (base: "Fix Fast RAM
+stability: hybrid registered/combinatorial WE based on speed") and the
+current HEAD (025ee20). Separates real fixes from red herrings and dead ends.
+
+## Starting Point (8b70279)
+
+- Turbo mode at 40 MHz (80 MHz PLL / 2)
+- No expansion card support (GVP SCSI caused crashes)
+- Single C7M-domain DTACK path for everything
+- DTACK_MB_n was input-only (no DMA DTACK drive)
+- INT2_n was an output (directly driven)
+- No safety timing between bus cycles
+- Async resets on AS_CPU_n edges (posedge AS_CPU_n in always blocks)
+- No SDC constraints for turbo_clk or CDC
+- All IO drive strengths at minimum (1)
+
+
+## What Actually Fixed Things
+
+These are the changes that solved real bugs, confirmed by testing. Each
+one addressed a specific failure mode that could be reproduced.
+
+### 1. BGACK_n synchronization on AS_MB_n_OE (025ee20) -- THE BIG ONE
+
+**Bug**: Raw BGACK_n used combinatorially in `AS_MB_n_OE`. During DMA
+transitions, ringing/reflections on the BGACK_n pin momentarily tri-stated
+AS mid-cycle. Expansion cards saw AS deassert, released DTACK, and the CPU
+hung forever waiting for DTACK to come back.
+
+**Fix**: Replace raw `BGACK_n` with `bgack_sync2` (2-stage C100M sync).
+
+```verilog
+// Before:
+assign AS_MB_n_OE = BG_68SEC000_n | !AS_CPU_n;
+// After:
+assign AS_MB_n_OE = (BG_68SEC000_n | !AS_CPU_n) & bgack_sync2;
+```
+
+**Evidence**: This single fix made GVP file copy, SysInfo drive test, and
+stress test all work reliably. Biggest stability improvement of the entire
+series.
+
+### 2. BGACK_n 2-stage synchronizer for all downstream logic (083d844, 025ee20)
+
+**Bug**: Raw BGACK_n feeding the `as_n` mux, fastram, sdcard_access, and
+dtack_oe_reg could glitch during DMA transitions, causing the as_n mux to
+momentarily select the wrong AS source. This could falsely reset the fastram
+DTACK counter mid-cycle.
+
+**Fix**: 2-stage C100M synchronizer, then 2-stage CLKCPU re-sync for
+CPU-domain consumers.
+
+```verilog
+reg bgack_sync1, bgack_sync2;
+always @(posedge C100M) begin
+    bgack_sync1 <= BGACK_n;
+    bgack_sync2 <= bgack_sync1;
+end
+```
+
+**Evidence**: Required for stable DMA coexistence. Without it, as_n mux
+glitches caused sporadic hangs under heavy DMA.
+
+### 3. as_n mux: BGACK instead of BG (083d844)
+
+**Bug**: `as_n` was selected by `BG_68SEC000_n` (Bus Grant), but BG can be
+deasserted by the arbiter while BGACK is still held by the DMA master. This
+caused the FPGA to switch AS source mid-DMA-cycle.
+
+**Fix**: Use BGACK (bus ownership) as the mux select.
+
+```verilog
+// Before:
+wire as_n = BG_68SEC000_n ? AS_CPU_n : AS_MB_n_IN;
+// After:
+wire as_n = bgack_sync2 ? AS_CPU_n : AS_MB_n_IN;
+```
+
+### 4. Bidirectional DTACK drive for DMA (88581e0)
+
+**Bug**: DTACK_MB_n was input-only. When GVP DMA accessed the FPGA's fast
+RAM, nothing drove DTACK on the motherboard bus. The DMA master hung waiting
+for acknowledgement.
+
+**Fix**: Made DTACK_MB_n bidirectional. FPGA drives DTACK LOW when DMA
+accesses fast RAM and the RAM controller is ready.
+
+```verilog
+reg dtack_oe_reg;
+always @(posedge CLKCPU) begin
+    dtack_oe_reg <= (!bgack_cpu && ram_access && !ram_dtack_n);
+end
+assign DTACK_MB_n_OUT = 1'b0;
+assign DTACK_MB_n_OE = dtack_oe_reg & !as_n;
+```
+
+### 5. C100M oversampled DTACK counter with pause-on-noise (8232f1d, 083d844)
+
+**Bug**: Single C7M samples of DTACK are too noise-sensitive for expansion
+cards. One noisy sample fires DTACK before the card has valid data, CPU
+reads bus pull-ups (0xFFFF). Confirmed: C7M-only DTACK caused GVP to
+return $FF/$FF status reads.
+
+**Fix**: 100 MHz oversampling counter requires 12 consecutive LOW samples
+(120ns) before asserting. Noise pauses the counter but doesn't reset it,
+so genuine DTACK eventually accumulates even on a noisy bus.
+
+**Evidence**: Directly confirmed by regression -- switching to C7M-only
+DTACK in a later experiment caused immediate GVP $FF/$FF failures.
+
+### 6. Safety countdown: precharge + setup timing (56c4953, 1671087)
+
+**Bug**: At turbo speed, back-to-back expansion bus cycles don't give the
+DTACK RC pullup enough time to discharge. Stale LOW DTACK from the previous
+cycle gets accepted as valid DTACK for the new cycle.
+
+**Fix**: Precharge (280ns) + setup (120ns) = 400ns minimum gap enforced
+between bus cycles. Cannot be reduced below ~280ns precharge on a loaded bus
+(confirmed by regression when reduced to 120ns).
+
+```verilog
+localparam [3:0] PRECHARGE_TICKS = 4'd7;   // 280ns at 25MHz
+localparam [2:0] SETUP_TICKS = 3'd3;       // 120ns at 25MHz
+```
+
+### 7. turbo_as_gate: combinatorial AS/DTACK blocking (351227b, 51f3d43)
+
+**Bug**: Stale mobo_as_n and mobo_dtack_n registers from the C7M domain
+could leak through at the start of a new turbo cycle (no C7M edge may fall
+in the short inter-cycle gap at 25MHz).
+
+**Fix**: Triple-OR gate blocks both AS output and DTACK input until safety
+is met.
+
+```verilog
+wire turbo_as_gate = mobo_as_n | AS_CPU_n | (cpu_speed_switch & !safety_ok);
+```
+
+This is used for AS output AND as the reset for the C100M DTACK counter,
+preventing stale DTACK accumulation during the safety countdown.
+
+### 8. Async reset elimination (dd95b84)
+
+**Bug**: `posedge AS_n` / `posedge AS_CPU_n` async resets on DTACK and OE
+registers caused recovery time violations when AS transitioned near a CLKCPU
+edge. The register could go metastable and stick, permanently hanging DTACK.
+
+**Fix**: Converted all async resets to synchronous checks. Instant AS
+termination handled by combinatorial gates instead.
+
+### 9. Turbo clock reduction: 40 MHz -> 25 MHz (51f3d43, 1671087)
+
+**Bug**: 40 MHz crashed within 2-3 minutes. The 68SEC000 is rated for
+20 MHz; 40 MHz exceeds the chip's timing margins.
+
+**Fix**: Dropped to 20 MHz initially (stable 2h23m), then 25 MHz (stable
+3h30m+). 25 MHz is the sweet spot -- 25% overclock while staying close
+enough to spec. PLL source changed from 80 MHz/4 to 100 MHz/4.
+
+### 10. SDC timing constraints (dd95b84, 1c6dae4)
+
+**Bug**: No constraints for turbo_clk meant the placer/router didn't know
+about the 25 MHz clock domain or CDC boundaries. Timing violations went
+undetected.
+
+**Fix**: Added create_clock for turbo_clk, set_clock_groups -asynchronous
+for all three domains, and set_false_path for quasi-static autoconfig
+registers.
+
+### 11. INT2_n changed from output to input (88581e0)
+
+**Bug**: INT2_n was directly driven as an output, but it's active on the
+Amiga bus from other sources. Driving it could cause bus contention with
+other interrupt sources.
+
+**Fix**: Changed to input, disconnected SD card's INT2_n output.
+
+### 12. Schmitt trigger on DTACK_MB_n_IN (51f3d43)
+
+Enabled in the Interface Designer (peri.xml). Provides hardware-level
+noise filtering on the DTACK input, complementing the C100M counter's
+firmware-level filtering.
+
+### 13. DMA address glitch filter in fastram (79f7008)
+
+**Bug**: During DMA cycles targeting other devices (e.g. chip RAM), address
+bus transitions could transiently match the SRAM address range, causing
+SRAM OE/WE to glitch and briefly drive the data bus.
+
+**Fix**: `safe_to_enable` gate in fastram.v requires address stability for
+1 CLKCPU cycle during DMA before enabling OE/WE. CPU access bypasses the
+filter for zero wait states.
+
+### 14. DMA wait states in fastram (88581e0)
+
+**Fix**: 6 wait states (150ns at 25MHz) for DMA access to SRAM, 0 for CPU.
+Gives the slower DMA path time to set up stable addresses and data.
+
+### 15. Bus arbiter CDC fix (025ee20)
+
+**Bug**: BG_68SEC000_n from the 25 MHz turbo domain was passed through a
+C7M register unsynchronized -- a CDC violation.
+
+**Fix**: Use existing 2-stage synchronizer `bg_68sec_sync[1]`.
+
+Note: BR_n_IN and BGACK_n were also changed to use their synchronizers,
+but these signals are already C7M-synchronous (Zorro bus) so the sync adds
+~280ns unnecessary latency. May want to revert those two back to raw.
+
+### 16. Boot timer extension: 3s -> 5s (79f7008)
+
+Gives expansion cards more time to initialize before the FPGA switches to
+turbo mode. Helped Ariadne cold boot reliability (though Ariadne has a
+separate hardware-level incompatibility).
+
+### 17. IO drive strength increase: 1 -> 3 (79f7008, final state)
+
+All bus-facing outputs (AS, DTACK_CPU, DTACK_MB, BR_68SEC000, D[15:0])
+increased to maximum drive strength. Helps overcome the SN74CBT16211 FET
+bus switch losses and loaded bus capacitance. Was reverted once (95495b3)
+and re-applied -- ended up keeping it.
+
+### 18. sdcard_access gated by BGACK (e32c6cd)
+
+**Bug**: During DMA, addresses could transiently match the SD card's
+autoconfig range, causing the FPGA to respond to an access meant for
+another device.
+
+**Fix**: Gate sdcard_access with `bgack_sync2` so it only matches during
+CPU cycles.
+
+
+## Red Herrings and Dead Ends
+
+Changes that were tried, didn't help (or made things worse), and were
+reverted. These are worth documenting to avoid repeating them.
+
+### A. Disabling FPGA RAM entirely (c32cfd1)
+
+Tried skipping RAM in autoconfig to avoid address contention with GVP.
+This was a diagnostic step that confirmed the problem was in bus timing,
+not address conflicts. Re-enabled once the real fixes were found.
+
+### B. Reduced safety parameters (tried during 025ee20 session, reverted)
+
+Reduced PRECHARGE 7->3, SETUP 3->1, DTACK_TICKS 12->6 to minimize the
+DS-before-AS protocol violation window. Caused file copy hangs -- 120ns
+precharge is too short for the bus RC pullup on a loaded Zorro bus.
+
+### C. C7M-only expansion DTACK (tried during 025ee20 session, reverted)
+
+Replaced the C100M counter path with a single C7M sample of DTACK for
+expansion cards. Caused immediate GVP boot failure ($FF/$FF status reads).
+A single C7M sample has no noise immunity -- one noisy sample fires DTACK
+before the card has valid data on the bus.
+
+### D. Armed gate on expansion DTACK path (51f3d43, removed in 025ee20 session)
+
+The armed gate requires 6 consecutive HIGHs (~320ns) before allowing any
+DTACK through. Works for legacy devices (slow DTACK, open-drain with
+pullup), but deadlocks on expansion cards that respond faster than 320ns.
+The C100M counter already provides stale DTACK protection for expansion,
+making the armed gate redundant and harmful there.
+
+### E. Drive strength increase/revert churn (f52d213, 95495b3)
+
+Drive strength was increased, then reverted, then re-applied. The increase
+helps marginally with signal integrity but didn't fix the core bugs (BGACK
+glitch, missing DTACK drive, etc). It survived in the final build but was
+never the difference between working and not working.
+
+### F. Ariadne-specific fixes (79f7008, 083d844 -- partially)
+
+Several changes were motivated by Ariadne compatibility: boot timer
+extension, DMA glitch filter, BGACK sync. The BGACK sync and DMA glitch
+filter genuinely help GVP and general DMA stability, but the Ariadne
+itself has a hardware-level incompatibility with the SF2000 rev 2b (3.3V
+output through FET bus switches is below 74HC CMOS VIH threshold). No
+firmware fix can address this.
+
+
+## Net Architecture Change Summary
+
+The firmware went from a simple "pass-through with clock switching" to a
+proper multi-clock-domain bus controller:
+
+| Aspect | Before (8b70279) | After (025ee20) |
+|--------|-------------------|------------------|
+| Turbo clock | 40 MHz | 25 MHz |
+| DTACK input | Single C7M sample | Dual path: C7M for legacy, C100M 12-tick counter for expansion |
+| Bus cycle timing | None | 400ns safety gap (precharge + setup) |
+| BGACK handling | Raw, unsynchronized | 2-stage C100M sync, 2-stage CLKCPU re-sync |
+| DMA DTACK | Not supported | Bidirectional drive with 6 wait states |
+| Async resets | On AS_CPU_n edges | All synchronous |
+| SDC constraints | C7M only | All 3 clock domains, CDC groups, false paths |
+| IO drive strength | Minimum (1) | Maximum (3) on bus outputs |
+| DTACK_MB_n | Input only | Bidirectional (inout) |
+| DTACK_MB_n input | No filtering | Schmitt trigger enabled |
+| INT2_n | Output (driven) | Input (tri-stated) |
+| Bus arbiter CDC | Raw signals | 2-stage synced (BG_68SEC000_n) |

--- a/SF2000-FW.peri.xml
+++ b/SF2000-FW.peri.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<efxpt:design_db name="SF2000-FW" device_def="T8Q144" version="2024.2.294" db_version="20242999" last_change_date="Sat Jan 10 14:20:44 2026" xmlns:efxpt="http://www.efinixinc.com/peri_design_db" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.efinixinc.com/peri_design_db peri_design_db.xsd ">
+<efxpt:design_db name="SF2000-FW" device_def="T8Q144" version="2025.2.288.2.10" db_version="20252006" last_change_date="Sun Jan 18 11:49:30 2026" xmlns:efxpt="http://www.efinixinc.com/peri_design_db" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.efinixinc.com/peri_design_db peri_design_db.xsd ">
     <efxpt:device_info>
         <efxpt:iobank_info>
             <efxpt:iobank name="1A" iostd="3.3 V LVTTL / LVCMOS"/>
@@ -26,7 +26,7 @@
         </efxpt:gpio>
         <efxpt:gpio name="AS_MB_n" gpio_def="GPIOB_RXP02" mode="inout" bus_name="" is_lvds_gpio="true" io_standard="3.3 V LVTTL / LVCMOS">
             <efxpt:input_config name="AS_MB_n_IN" name_ddio_lo="" conn_type="normal" is_register="false" clock_name="" is_clock_inverted="false" pull_option="weak pullup" is_schmitt_trigger="false" ddio_type="none"/>
-            <efxpt:output_config name="AS_MB_n_OUT" name_ddio_lo="" register_option="none" clock_name="" is_clock_inverted="false" is_slew_rate="false" tied_option="none" ddio_type="none" drive_strength="1"/>
+            <efxpt:output_config name="AS_MB_n_OUT" name_ddio_lo="" register_option="none" clock_name="" is_clock_inverted="false" is_slew_rate="false" tied_option="none" ddio_type="none" drive_strength="3"/>
             <efxpt:output_enable_config name="AS_MB_n_OE" is_register="false" clock_name="" is_clock_inverted="false"/>
         </efxpt:gpio>
         <efxpt:gpio name="A[10]" gpio_def="GPIOR_83" mode="input" bus_name="A" is_lvds_gpio="false" io_standard="3.3 V LVTTL / LVCMOS">
@@ -118,7 +118,7 @@
             <efxpt:output_enable_config name="BOSS_n_OE" is_register="false" clock_name="" is_clock_inverted="false"/>
         </efxpt:gpio>
         <efxpt:gpio name="BR_68SEC000_n" gpio_def="GPIOB_TXN04" mode="output" bus_name="" is_lvds_gpio="true" io_standard="3.3 V LVTTL / LVCMOS">
-            <efxpt:output_config name="BR_68SEC000_n" name_ddio_lo="" register_option="none" clock_name="" is_clock_inverted="false" is_slew_rate="false" tied_option="none" ddio_type="none" drive_strength="1"/>
+            <efxpt:output_config name="BR_68SEC000_n" name_ddio_lo="" register_option="none" clock_name="" is_clock_inverted="false" is_slew_rate="false" tied_option="none" ddio_type="none" drive_strength="3"/>
         </efxpt:gpio>
         <efxpt:gpio name="BR_n" gpio_def="GPIOL_65" mode="inout" bus_name="" is_lvds_gpio="false" io_standard="3.3 V LVTTL / LVCMOS">
             <efxpt:input_config name="BR_n_IN" name_ddio_lo="" conn_type="normal" is_register="false" clock_name="" is_clock_inverted="false" pull_option="none" is_schmitt_trigger="false" ddio_type="none"/>
@@ -138,89 +138,91 @@
             <efxpt:output_config name="CLKCPU" name_ddio_lo="" register_option="none" clock_name="" is_clock_inverted="false" is_slew_rate="false" tied_option="none" ddio_type="none" drive_strength="2"/>
         </efxpt:gpio>
         <efxpt:gpio name="DTACK_CPU_n" gpio_def="GPIOB_TXN06" mode="output" bus_name="" is_lvds_gpio="true" io_standard="3.3 V LVTTL / LVCMOS">
-            <efxpt:output_config name="DTACK_CPU_n" name_ddio_lo="" register_option="none" clock_name="" is_clock_inverted="false" is_slew_rate="false" tied_option="none" ddio_type="none" drive_strength="1"/>
+            <efxpt:output_config name="DTACK_CPU_n" name_ddio_lo="" register_option="none" clock_name="" is_clock_inverted="false" is_slew_rate="false" tied_option="none" ddio_type="none" drive_strength="3"/>
         </efxpt:gpio>
-        <efxpt:gpio name="DTACK_MB_n" gpio_def="GPIOB_TXN09" mode="input" bus_name="" is_lvds_gpio="true" io_standard="3.3 V LVTTL / LVCMOS">
-            <efxpt:input_config name="DTACK_MB_n" name_ddio_lo="" conn_type="normal" is_register="false" clock_name="" is_clock_inverted="false" pull_option="weak pullup" is_schmitt_trigger="false" ddio_type="none"/>
+        <efxpt:gpio name="DTACK_MB_n" gpio_def="GPIOB_TXN09" mode="inout" bus_name="" is_lvds_gpio="true" io_standard="3.3 V LVTTL / LVCMOS">
+            <efxpt:input_config name="DTACK_MB_n_IN" name_ddio_lo="" conn_type="normal" is_register="false" clock_name="" is_clock_inverted="false" pull_option="weak pullup" is_schmitt_trigger="true" ddio_type="none"/>
+            <efxpt:output_config name="DTACK_MB_n_OUT" name_ddio_lo="" register_option="none" clock_name="" is_clock_inverted="false" is_slew_rate="false" tied_option="none" ddio_type="none" drive_strength="3"/>
+            <efxpt:output_enable_config name="DTACK_MB_n_OE" is_register="false" clock_name="" is_clock_inverted="false"/>
         </efxpt:gpio>
         <efxpt:gpio name="D[0]" gpio_def="GPIOR_123" mode="inout" bus_name="D" is_lvds_gpio="false" io_standard="3.3 V LVTTL / LVCMOS">
             <efxpt:input_config name="D_IN[0]" name_ddio_lo="" conn_type="normal" is_register="false" clock_name="" is_clock_inverted="false" pull_option="none" is_schmitt_trigger="false" ddio_type="none"/>
-            <efxpt:output_config name="D_OUT[0]" name_ddio_lo="" register_option="none" clock_name="" is_clock_inverted="false" is_slew_rate="false" tied_option="none" ddio_type="none" drive_strength="1"/>
+            <efxpt:output_config name="D_OUT[0]" name_ddio_lo="" register_option="none" clock_name="" is_clock_inverted="false" is_slew_rate="false" tied_option="none" ddio_type="none" drive_strength="3"/>
             <efxpt:output_enable_config name="D_OE[0]" is_register="false" clock_name="" is_clock_inverted="false"/>
         </efxpt:gpio>
         <efxpt:gpio name="D[10]" gpio_def="GPIOB_RXP03" mode="inout" bus_name="D" is_lvds_gpio="true" io_standard="3.3 V LVTTL / LVCMOS">
             <efxpt:input_config name="D_IN[10]" name_ddio_lo="" conn_type="normal" is_register="false" clock_name="" is_clock_inverted="false" pull_option="none" is_schmitt_trigger="false" ddio_type="none"/>
-            <efxpt:output_config name="D_OUT[10]" name_ddio_lo="" register_option="none" clock_name="" is_clock_inverted="false" is_slew_rate="false" tied_option="none" ddio_type="none" drive_strength="1"/>
+            <efxpt:output_config name="D_OUT[10]" name_ddio_lo="" register_option="none" clock_name="" is_clock_inverted="false" is_slew_rate="false" tied_option="none" ddio_type="none" drive_strength="3"/>
             <efxpt:output_enable_config name="D_OE[10]" is_register="false" clock_name="" is_clock_inverted="false"/>
         </efxpt:gpio>
         <efxpt:gpio name="D[11]" gpio_def="GPIOB_RXN07" mode="inout" bus_name="D" is_lvds_gpio="true" io_standard="3.3 V LVTTL / LVCMOS">
             <efxpt:input_config name="D_IN[11]" name_ddio_lo="" conn_type="normal" is_register="false" clock_name="" is_clock_inverted="false" pull_option="none" is_schmitt_trigger="false" ddio_type="none"/>
-            <efxpt:output_config name="D_OUT[11]" name_ddio_lo="" register_option="none" clock_name="" is_clock_inverted="false" is_slew_rate="false" tied_option="none" ddio_type="none" drive_strength="1"/>
+            <efxpt:output_config name="D_OUT[11]" name_ddio_lo="" register_option="none" clock_name="" is_clock_inverted="false" is_slew_rate="false" tied_option="none" ddio_type="none" drive_strength="3"/>
             <efxpt:output_enable_config name="D_OE[11]" is_register="false" clock_name="" is_clock_inverted="false"/>
         </efxpt:gpio>
         <efxpt:gpio name="D[12]" gpio_def="GPIOB_RXP07" mode="inout" bus_name="D" is_lvds_gpio="true" io_standard="3.3 V LVTTL / LVCMOS">
             <efxpt:input_config name="D_IN[12]" name_ddio_lo="" conn_type="normal" is_register="false" clock_name="" is_clock_inverted="false" pull_option="none" is_schmitt_trigger="false" ddio_type="none"/>
-            <efxpt:output_config name="D_OUT[12]" name_ddio_lo="" register_option="none" clock_name="" is_clock_inverted="false" is_slew_rate="false" tied_option="none" ddio_type="none" drive_strength="1"/>
+            <efxpt:output_config name="D_OUT[12]" name_ddio_lo="" register_option="none" clock_name="" is_clock_inverted="false" is_slew_rate="false" tied_option="none" ddio_type="none" drive_strength="3"/>
             <efxpt:output_enable_config name="D_OE[12]" is_register="false" clock_name="" is_clock_inverted="false"/>
         </efxpt:gpio>
         <efxpt:gpio name="D[13]" gpio_def="GPIOB_RXP10" mode="inout" bus_name="D" is_lvds_gpio="true" io_standard="3.3 V LVTTL / LVCMOS">
             <efxpt:input_config name="D_IN[13]" name_ddio_lo="" conn_type="normal" is_register="false" clock_name="" is_clock_inverted="false" pull_option="none" is_schmitt_trigger="false" ddio_type="none"/>
-            <efxpt:output_config name="D_OUT[13]" name_ddio_lo="" register_option="none" clock_name="" is_clock_inverted="false" is_slew_rate="false" tied_option="none" ddio_type="none" drive_strength="1"/>
+            <efxpt:output_config name="D_OUT[13]" name_ddio_lo="" register_option="none" clock_name="" is_clock_inverted="false" is_slew_rate="false" tied_option="none" ddio_type="none" drive_strength="3"/>
             <efxpt:output_enable_config name="D_OE[13]" is_register="false" clock_name="" is_clock_inverted="false"/>
         </efxpt:gpio>
         <efxpt:gpio name="D[14]" gpio_def="GPIOB_RXN10" mode="inout" bus_name="D" is_lvds_gpio="true" io_standard="3.3 V LVTTL / LVCMOS">
             <efxpt:input_config name="D_IN[14]" name_ddio_lo="" conn_type="normal" is_register="false" clock_name="" is_clock_inverted="false" pull_option="none" is_schmitt_trigger="false" ddio_type="none"/>
-            <efxpt:output_config name="D_OUT[14]" name_ddio_lo="" register_option="none" clock_name="" is_clock_inverted="false" is_slew_rate="false" tied_option="none" ddio_type="none" drive_strength="1"/>
+            <efxpt:output_config name="D_OUT[14]" name_ddio_lo="" register_option="none" clock_name="" is_clock_inverted="false" is_slew_rate="false" tied_option="none" ddio_type="none" drive_strength="3"/>
             <efxpt:output_enable_config name="D_OE[14]" is_register="false" clock_name="" is_clock_inverted="false"/>
         </efxpt:gpio>
         <efxpt:gpio name="D[15]" gpio_def="GPIOB_RXN12" mode="inout" bus_name="D" is_lvds_gpio="true" io_standard="3.3 V LVTTL / LVCMOS">
             <efxpt:input_config name="D_IN[15]" name_ddio_lo="" conn_type="normal" is_register="false" clock_name="" is_clock_inverted="false" pull_option="none" is_schmitt_trigger="false" ddio_type="none"/>
-            <efxpt:output_config name="D_OUT[15]" name_ddio_lo="" register_option="none" clock_name="" is_clock_inverted="false" is_slew_rate="false" tied_option="none" ddio_type="none" drive_strength="1"/>
+            <efxpt:output_config name="D_OUT[15]" name_ddio_lo="" register_option="none" clock_name="" is_clock_inverted="false" is_slew_rate="false" tied_option="none" ddio_type="none" drive_strength="3"/>
             <efxpt:output_enable_config name="D_OE[15]" is_register="false" clock_name="" is_clock_inverted="false"/>
         </efxpt:gpio>
         <efxpt:gpio name="D[1]" gpio_def="GPIOR_125" mode="inout" bus_name="D" is_lvds_gpio="false" io_standard="3.3 V LVTTL / LVCMOS">
             <efxpt:input_config name="D_IN[1]" name_ddio_lo="" conn_type="normal" is_register="false" clock_name="" is_clock_inverted="false" pull_option="none" is_schmitt_trigger="false" ddio_type="none"/>
-            <efxpt:output_config name="D_OUT[1]" name_ddio_lo="" register_option="none" clock_name="" is_clock_inverted="false" is_slew_rate="false" tied_option="none" ddio_type="none" drive_strength="1"/>
+            <efxpt:output_config name="D_OUT[1]" name_ddio_lo="" register_option="none" clock_name="" is_clock_inverted="false" is_slew_rate="false" tied_option="none" ddio_type="none" drive_strength="3"/>
             <efxpt:output_enable_config name="D_OE[1]" is_register="false" clock_name="" is_clock_inverted="false"/>
         </efxpt:gpio>
         <efxpt:gpio name="D[2]" gpio_def="GPIOR_128" mode="inout" bus_name="D" is_lvds_gpio="false" io_standard="3.3 V LVTTL / LVCMOS">
             <efxpt:input_config name="D_IN[2]" name_ddio_lo="" conn_type="normal" is_register="false" clock_name="" is_clock_inverted="false" pull_option="none" is_schmitt_trigger="false" ddio_type="none"/>
-            <efxpt:output_config name="D_OUT[2]" name_ddio_lo="" register_option="none" clock_name="" is_clock_inverted="false" is_slew_rate="false" tied_option="none" ddio_type="none" drive_strength="1"/>
+            <efxpt:output_config name="D_OUT[2]" name_ddio_lo="" register_option="none" clock_name="" is_clock_inverted="false" is_slew_rate="false" tied_option="none" ddio_type="none" drive_strength="3"/>
             <efxpt:output_enable_config name="D_OE[2]" is_register="false" clock_name="" is_clock_inverted="false"/>
         </efxpt:gpio>
         <efxpt:gpio name="D[3]" gpio_def="GPIOR_129" mode="inout" bus_name="D" is_lvds_gpio="false" io_standard="3.3 V LVTTL / LVCMOS">
             <efxpt:input_config name="D_IN[3]" name_ddio_lo="" conn_type="normal" is_register="false" clock_name="" is_clock_inverted="false" pull_option="none" is_schmitt_trigger="false" ddio_type="none"/>
-            <efxpt:output_config name="D_OUT[3]" name_ddio_lo="" register_option="none" clock_name="" is_clock_inverted="false" is_slew_rate="false" tied_option="none" ddio_type="none" drive_strength="1"/>
+            <efxpt:output_config name="D_OUT[3]" name_ddio_lo="" register_option="none" clock_name="" is_clock_inverted="false" is_slew_rate="false" tied_option="none" ddio_type="none" drive_strength="3"/>
             <efxpt:output_enable_config name="D_OE[3]" is_register="false" clock_name="" is_clock_inverted="false"/>
         </efxpt:gpio>
         <efxpt:gpio name="D[4]" gpio_def="GPIOR_132" mode="inout" bus_name="D" is_lvds_gpio="false" io_standard="3.3 V LVTTL / LVCMOS">
             <efxpt:input_config name="D_IN[4]" name_ddio_lo="" conn_type="normal" is_register="false" clock_name="" is_clock_inverted="false" pull_option="none" is_schmitt_trigger="false" ddio_type="none"/>
-            <efxpt:output_config name="D_OUT[4]" name_ddio_lo="" register_option="none" clock_name="" is_clock_inverted="false" is_slew_rate="false" tied_option="none" ddio_type="none" drive_strength="1"/>
+            <efxpt:output_config name="D_OUT[4]" name_ddio_lo="" register_option="none" clock_name="" is_clock_inverted="false" is_slew_rate="false" tied_option="none" ddio_type="none" drive_strength="3"/>
             <efxpt:output_enable_config name="D_OE[4]" is_register="false" clock_name="" is_clock_inverted="false"/>
         </efxpt:gpio>
         <efxpt:gpio name="D[5]" gpio_def="GPIOR_133" mode="inout" bus_name="D" is_lvds_gpio="false" io_standard="3.3 V LVTTL / LVCMOS">
             <efxpt:input_config name="D_IN[5]" name_ddio_lo="" conn_type="normal" is_register="false" clock_name="" is_clock_inverted="false" pull_option="none" is_schmitt_trigger="false" ddio_type="none"/>
-            <efxpt:output_config name="D_OUT[5]" name_ddio_lo="" register_option="none" clock_name="" is_clock_inverted="false" is_slew_rate="false" tied_option="none" ddio_type="none" drive_strength="1"/>
+            <efxpt:output_config name="D_OUT[5]" name_ddio_lo="" register_option="none" clock_name="" is_clock_inverted="false" is_slew_rate="false" tied_option="none" ddio_type="none" drive_strength="3"/>
             <efxpt:output_enable_config name="D_OE[5]" is_register="false" clock_name="" is_clock_inverted="false"/>
         </efxpt:gpio>
         <efxpt:gpio name="D[6]" gpio_def="GPIOR_135" mode="inout" bus_name="D" is_lvds_gpio="false" io_standard="3.3 V LVTTL / LVCMOS">
             <efxpt:input_config name="D_IN[6]" name_ddio_lo="" conn_type="normal" is_register="false" clock_name="" is_clock_inverted="false" pull_option="none" is_schmitt_trigger="false" ddio_type="none"/>
-            <efxpt:output_config name="D_OUT[6]" name_ddio_lo="" register_option="none" clock_name="" is_clock_inverted="false" is_slew_rate="false" tied_option="none" ddio_type="none" drive_strength="1"/>
+            <efxpt:output_config name="D_OUT[6]" name_ddio_lo="" register_option="none" clock_name="" is_clock_inverted="false" is_slew_rate="false" tied_option="none" ddio_type="none" drive_strength="3"/>
             <efxpt:output_enable_config name="D_OE[6]" is_register="false" clock_name="" is_clock_inverted="false"/>
         </efxpt:gpio>
         <efxpt:gpio name="D[7]" gpio_def="GPIOR_136" mode="inout" bus_name="D" is_lvds_gpio="false" io_standard="3.3 V LVTTL / LVCMOS">
             <efxpt:input_config name="D_IN[7]" name_ddio_lo="" conn_type="normal" is_register="false" clock_name="" is_clock_inverted="false" pull_option="none" is_schmitt_trigger="false" ddio_type="none"/>
-            <efxpt:output_config name="D_OUT[7]" name_ddio_lo="" register_option="none" clock_name="" is_clock_inverted="false" is_slew_rate="false" tied_option="none" ddio_type="none" drive_strength="1"/>
+            <efxpt:output_config name="D_OUT[7]" name_ddio_lo="" register_option="none" clock_name="" is_clock_inverted="false" is_slew_rate="false" tied_option="none" ddio_type="none" drive_strength="3"/>
             <efxpt:output_enable_config name="D_OE[7]" is_register="false" clock_name="" is_clock_inverted="false"/>
         </efxpt:gpio>
         <efxpt:gpio name="D[8]" gpio_def="GPIOB_RXN02" mode="inout" bus_name="D" is_lvds_gpio="true" io_standard="3.3 V LVTTL / LVCMOS">
             <efxpt:input_config name="D_IN[8]" name_ddio_lo="" conn_type="normal" is_register="false" clock_name="" is_clock_inverted="false" pull_option="none" is_schmitt_trigger="false" ddio_type="none"/>
-            <efxpt:output_config name="D_OUT[8]" name_ddio_lo="" register_option="none" clock_name="" is_clock_inverted="false" is_slew_rate="false" tied_option="none" ddio_type="none" drive_strength="1"/>
+            <efxpt:output_config name="D_OUT[8]" name_ddio_lo="" register_option="none" clock_name="" is_clock_inverted="false" is_slew_rate="false" tied_option="none" ddio_type="none" drive_strength="3"/>
             <efxpt:output_enable_config name="D_OE[8]" is_register="false" clock_name="" is_clock_inverted="false"/>
         </efxpt:gpio>
         <efxpt:gpio name="D[9]" gpio_def="GPIOB_RXN03" mode="inout" bus_name="D" is_lvds_gpio="true" io_standard="3.3 V LVTTL / LVCMOS">
             <efxpt:input_config name="D_IN[9]" name_ddio_lo="" conn_type="normal" is_register="false" clock_name="" is_clock_inverted="false" pull_option="none" is_schmitt_trigger="false" ddio_type="none"/>
-            <efxpt:output_config name="D_OUT[9]" name_ddio_lo="" register_option="none" clock_name="" is_clock_inverted="false" is_slew_rate="false" tied_option="none" ddio_type="none" drive_strength="1"/>
+            <efxpt:output_config name="D_OUT[9]" name_ddio_lo="" register_option="none" clock_name="" is_clock_inverted="false" is_slew_rate="false" tied_option="none" ddio_type="none" drive_strength="3"/>
             <efxpt:output_enable_config name="D_OE[9]" is_register="false" clock_name="" is_clock_inverted="false"/>
         </efxpt:gpio>
         <efxpt:gpio name="E" gpio_def="GPIOL_25" mode="inout" bus_name="" is_lvds_gpio="false" io_standard="3.3 V LVTTL / LVCMOS">
@@ -249,8 +251,8 @@
         <efxpt:gpio name="HLT_n" gpio_def="GPIOB_TXP04" mode="input" bus_name="" is_lvds_gpio="true" io_standard="3.3 V LVTTL / LVCMOS">
             <efxpt:input_config name="HLT_n" name_ddio_lo="" conn_type="normal" is_register="false" clock_name="" is_clock_inverted="false" pull_option="weak pullup" is_schmitt_trigger="false" ddio_type="none"/>
         </efxpt:gpio>
-        <efxpt:gpio name="INT2_n" gpio_def="GPIOL_41" mode="output" bus_name="" is_lvds_gpio="false" io_standard="3.3 V LVTTL / LVCMOS">
-            <efxpt:output_config name="INT2_n" name_ddio_lo="" register_option="none" clock_name="" is_clock_inverted="false" is_slew_rate="false" tied_option="none" ddio_type="none" drive_strength="1"/>
+        <efxpt:gpio name="INT2_n" gpio_def="GPIOL_41" mode="input" bus_name="" is_lvds_gpio="false" io_standard="3.3 V LVTTL / LVCMOS">
+            <efxpt:input_config name="INT2_n_IN" name_ddio_lo="" conn_type="normal" is_register="false" clock_name="" is_clock_inverted="false" pull_option="none" is_schmitt_trigger="false" ddio_type="none"/>
         </efxpt:gpio>
         <efxpt:gpio name="INT6_n" gpio_def="GPIOB_CLKN0" mode="input" bus_name="" is_lvds_gpio="true" io_standard="3.3 V LVTTL / LVCMOS">
             <efxpt:input_config name="INT6_n" name_ddio_lo="" conn_type="normal" is_register="false" clock_name="" is_clock_inverted="false" pull_option="none" is_schmitt_trigger="false" ddio_type="none"/>
@@ -341,8 +343,8 @@
     </efxpt:gpio_info>
     <efxpt:pll_info>
         <efxpt:pll name="pll_inst1" pll_def="PLL_TR0" ref_clock_name="" ref_clock_freq="20.0000" multiplier="80" pre_divider="1" post_divider="2" reset_name="" locked_name="" is_ipfrz="false" is_bypass_lock="true">
-            <efxpt:output_clock name="pll_inst1_CLKOUT0" number="0" out_divider="10" adv_out_phase_shift="0"/>
-            <efxpt:output_clock name="pll_inst1_CLKOUT1" number="1" out_divider="8" adv_out_phase_shift="0"/>
+            <efxpt:output_clock name="pll_inst1_CLKOUT0" number="0" out_divider="10" adv_out_phase_shift="0" conn_type="gclk"/>
+            <efxpt:output_clock name="pll_inst1_CLKOUT1" number="1" out_divider="8" adv_out_phase_shift="0" conn_type="gclk"/>
             <efxpt:adv_prop ref_clock_mode="external" ref_clock1_name="" ext_ref_clock_id="2" clksel_name="" feedback_clock_name="" feedback_mode="internal"/>
         </efxpt:pll>
     </efxpt:pll_info>

--- a/SF2000-FW.sdc
+++ b/SF2000-FW.sdc
@@ -1,6 +1,25 @@
 
 # PLL Constraints
 #################
-#create_clock -period 70.00 C14M
 create_clock -period 140.00 C7M_n
 
+# turbo_clk (25 MHz): PLL 100 MHz / 4, drives CLKCPU in turbo mode.
+# Using create_clock because Efinity cannot trace create_generated_clock
+# through the global clock buffer from the PLL output to this FF.
+create_clock -period 40.00 -name turbo_clk [get_pins {turbo_clk~FF|Q}]
+
+# CDC: Three asynchronous clock domains.
+# All cross-domain paths use 2-stage synchronizers — no timing analysis needed.
+set_clock_groups -asynchronous \
+    -group {C7M_n} \
+    -group {turbo_clk} \
+    -group {pll_inst1_CLKOUT1}
+
+# False paths: Quasi-static autoconfig registers (C7M domain)
+# These only change during boot autoconfig and are completely static
+# during normal operation. Eliminates false hold violations on
+# base_ram/ram_configured_n → fastram OE/WE paths that waste PnR effort.
+# Using get_cells -from (Efinity rejects get_pins |Q as a startpoint).
+set_false_path -from [get_cells {base_ram[*]~FF}]
+set_false_path -from [get_cells {ram_configured_n~FF}]
+set_false_path -from [get_cells {sd_configured_n~FF}]

--- a/SF2000-FW.xml
+++ b/SF2000-FW.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<efx:project name="SF2000-FW" description="" last_change="1768294784" sw_version="2024.2.294" last_run_state="pass" last_run_flow="bitstream" config_result_in_sync="true" design_ood="change" place_ood="sync" route_ood="sync" xmlns:efx="http://www.efinixinc.com/enf_proj" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.efinixinc.com/enf_proj enf_proj.xsd">
+<efx:project name="SF2000-FW" description="" last_change="1776539067" sw_version="2025.2.288.2.10" last_run_state="pass" last_run_flow="bitstream" config_result_in_sync="true" design_ood="change" place_ood="sync" route_ood="sync" xmlns:efx="http://www.efinixinc.com/enf_proj" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.efinixinc.com/enf_proj enf_proj.xsd">
     <efx:device_info>
         <efx:family name="Trion"/>
         <efx:device name="T8Q144"/>
@@ -25,9 +25,9 @@
         <efx:sdc_file name="SF2000-FW.sdc"/>
         <efx:inter_file name=""/>
     </efx:constraint_info>
-    <efx:isf_info/>
     <efx:sim_info/>
     <efx:misc_info/>
+    <efx:ooc_info/>
     <efx:ip_info/>
     <efx:synthesis tool_name="efx_map">
         <efx:param name="work_dir" value="work_syn" value_type="e_string"/>
@@ -64,17 +64,21 @@
         <efx:param name="max_threads" value="-1" value_type="e_integer"/>
         <efx:param name="mult_input_regs_packing" value="1" value_type="e_option"/>
         <efx:param name="mult_output_regs_packing" value="1" value_type="e_option"/>
+        <efx:param name="enable-mark-debug" value="1" value_type="e_option"/>
+        <efx:param name="max-bit-blast-mem-size" value="10240" value_type="e_integer"/>
+        <efx:param name="suppress_info_msgs" value="off" value_type="e_bool"/>
+        <efx:param name="suppress_warning_msgs" value="off" value_type="e_bool"/>
     </efx:synthesis>
     <efx:place_and_route tool_name="efx_pnr">
         <efx:param name="work_dir" value="work_pnr" value_type="e_string"/>
         <efx:param name="verbose" value="off" value_type="e_bool"/>
-        <efx:param name="load_delaym" value="on" value_type="e_bool"/>
-        <efx:param name="optimization_level" value="NULL" value_type="e_option"/>
         <efx:param name="seed" value="1" value_type="e_integer"/>
         <efx:param name="placer_effort_level" value="2" value_type="e_option"/>
         <efx:param name="max_threads" value="-1" value_type="e_integer"/>
         <efx:param name="print_critical_path" value="10" value_type="e_integer"/>
         <efx:param name="classic_flow" value="off" value_type="e_noarg"/>
+        <efx:param name="suppress_info_msgs" value="off" value_type="e_bool"/>
+        <efx:param name="suppress_warning_msgs" value="off" value_type="e_bool"/>
     </efx:place_and_route>
     <efx:bitstream_generation tool_name="efx_pgm">
         <efx:param name="mode" value="active" value_type="e_option"/>

--- a/rtl/autoconfig_zii.v
+++ b/rtl/autoconfig_zii.v
@@ -32,9 +32,9 @@ localparam [7:0]  RAM_PROD_ID = 8'd10;    // 5194/10 - SF2000, Memory Master (4M
 localparam [7:0]  SD_PROD_ID  = 8'd11;    // 5194/11 - SF2000, SD card controller I/O device (64K)
 localparam [15:0] SERIAL      = 16'd0;
 
-reg [1:0] configured_n = 2'b11;
+reg [1:0] configured_n = 2'b11;  // Both unconfigured
 reg [1:0] shutup_n = 2'b11;
-reg [1:0] config_out_n = 2'b11;
+reg [1:0] config_out_n = 2'b11;  // Start with RAM
 
 wire autoconfig_access = !CFGIN_n && CFGOUT_n && (A_HIGH == 8'hE8) && !AS_CPU_n;
 
@@ -44,15 +44,15 @@ assign SD_CONFIGURED_n = configured_n[SD_CARD];
 assign CFGOUT_n = |config_out_n;
 assign DATA_OE = autoconfig_access && RW_n && !DS_n;
 
-always @(negedge RESET_n or posedge C7M) begin
+always @(negedge RESET_n or posedge AS_CPU_n) begin
 
     if (!RESET_n) begin
 
-        config_out_n <= 2'b11;
+        config_out_n <= 2'b11;  // Start with RAM
 
     end else begin
 
-        if (AS_CPU_n) config_out_n <= configured_n & shutup_n;
+        config_out_n <= configured_n & shutup_n;
 
     end
 end
@@ -61,7 +61,7 @@ always @(negedge RESET_n or posedge C7M) begin
 
     if (!RESET_n) begin
 
-        configured_n <= 2'b11;
+        configured_n <= 2'b11;  // Both unconfigured
         shutup_n <= 2'b11;
 
     end else begin
@@ -158,6 +158,5 @@ always @(negedge RESET_n or posedge C7M) begin
         end
     end
 end
-
 
 endmodule

--- a/rtl/bus_arbiter.v
+++ b/rtl/bus_arbiter.v
@@ -34,18 +34,11 @@ module bus_arbiter(
 );
 
 /*
-Hybrid Bus Arbiter
+Bus Arbiter
 
-Takes KEY working elements from user's proven firmware:
-1. BR_68SEC000_n = 0 at reset (hold 68SEC000!)
-2. Fast bootstrap check (not 100 clocks)
-3. Condition: (BG_n_IN != 0 || JP2 != 0)
-4. BOSS_n_IN HIGH = B2000
-
-Keeps BETTER structure from previous attempt:
-1. Synchronizers for metastability protection
-2. Cleaner state machine
-3. Clear mode separation
+Detects machine type (A2000 vs B2000) and CPU presence at boot.
+Manages 3-way bus arbitration between 68SEC000, internal 68000, and
+external DMA masters. All external signals use 2-stage synchronizers.
 */
 
 //=============================================================================
@@ -197,10 +190,10 @@ always @(posedge C7M) begin
             if (dma_en) begin
                 // Mode 1 or Mode 3: DMA enabled
                 BR_n_OE <= 1'b0;                           // Don't drive BR to internal CPU
-                BR_68SEC000_n <= BR_n_IN & BGACK_n;        // 3-to-2 mapping (your elegant formula!)
-                
+                BR_68SEC000_n <= br_n_in_sync[1] & bgack_sync[1]; // 3-to-2 mapping (synced)
+
                 BG_n_OE <= 1'b1;                           // Drive BG to external DMA
-                BG_n_OUT <= BG_68SEC000_n;                 // Pass through 68SEC000's BG
+                BG_n_OUT <= bg_68sec_sync[1];              // Pass through 68SEC000's BG (synced — CDC from 25MHz)
                 
             end else begin
                 // Mode 2: A500 with CPU, no DMA

--- a/rtl/fastram.v
+++ b/rtl/fastram.v
@@ -3,6 +3,7 @@
 
 module fastram(
     input wire CLKCPU,
+    input wire BGACK_n,
     input wire CPU_SPEED_SWITCH,
     input wire [23:21] A,
     input wire JP4,
@@ -27,15 +28,8 @@ module fastram(
 /*
 Fast RAM Controller - Conditional Registered OE/WE
 
-KEY INSIGHT:
-- At 7 MHz: Combinatorial OE/WE works fine (always worked!)
-- At turbo: Need registered OE/WE for longer write pulses (stable writes)
-
-Solution: Use registered OE/WE only at turbo speeds!
-
-This way:
-- 7 MHz: Fast, combinatorial (DMA/HCII+8 works) ✅
-- Turbo: Registered negedge WE (stable, reliable writes) ✅
+7 MHz: Combinatorial OE/WE (fast, DMA-compatible).
+Turbo: Registered OE/WE on negedge for longer write pulses.
 */
 
 /*
@@ -53,6 +47,22 @@ wire second_4MB_access = !AS_n && !RAM_CONFIGURED_n && JP4 && ( (A == (BASE_RAM 
 
 assign RAM_ACCESS = JP4 ? (first_4MB_access || second_4MB_access) : first_4MB_access;
 
+// Filter address glitches during external DMA.
+// Address transitions can transiently match the SRAM range, causing
+// OE/WE to glitch. Requires 1-clock address stability before enabling.
+reg dma_ram_valid;
+always @(posedge CLKCPU) begin
+    if (AS_n)
+        dma_ram_valid <= 1'b0;
+    else
+        dma_ram_valid <= RAM_ACCESS;
+end
+
+// Gate for combinatorial OE/WE:
+// If DMA (!BGACK_n), requires 1-clock stability to prevent address glitches.
+// If CPU (BGACK_n), bypasses filter for 0-wait-state performance.
+wire safe_to_enable = BGACK_n ? 1'b1 : dma_ram_valid;
+
 //=============================================================================
 // Registered OE/WE Signals (for turbo mode)
 //=============================================================================
@@ -65,7 +75,7 @@ reg WE_BANK0_EVEN_n_reg = 1'b1;
 reg WE_BANK1_EVEN_n_reg = 1'b1;
 
 // OE registered on posedge
-always @(posedge CLKCPU or posedge AS_n) begin
+always @(posedge CLKCPU) begin
     if (AS_n) begin
         OE_BANK0_n_reg <= 1'b1;
         OE_BANK1_n_reg <= 1'b1;
@@ -76,7 +86,7 @@ always @(posedge CLKCPU or posedge AS_n) begin
 end
 
 // WE registered on negedge (for maximum write time)
-always @(negedge CLKCPU or posedge AS_n) begin
+always @(negedge CLKCPU) begin
     if (AS_n) begin
         WE_BANK0_ODD_n_reg <= 1'b1;
         WE_BANK1_ODD_n_reg <= 1'b1;
@@ -94,14 +104,14 @@ end
 // Combinatorial OE/WE Signals (for 7 MHz mode)
 //=============================================================================
 
-wire OE_BANK0_n_comb = first_4MB_access && RW_n && !DS_n ? 1'b0 : 1'b1;
-wire OE_BANK1_n_comb = second_4MB_access && RW_n && !DS_n ? 1'b0 : 1'b1;
+wire OE_BANK0_n_comb = first_4MB_access && safe_to_enable && RW_n && !DS_n ? 1'b0 : 1'b1;
+wire OE_BANK1_n_comb = second_4MB_access && safe_to_enable && RW_n && !DS_n ? 1'b0 : 1'b1;
 
-wire WE_BANK0_ODD_n_comb = first_4MB_access && !RW_n && !LDS_n ? 1'b0 : 1'b1;
-wire WE_BANK1_ODD_n_comb = second_4MB_access && !RW_n && !LDS_n ? 1'b0 : 1'b1;
+wire WE_BANK0_ODD_n_comb = first_4MB_access && safe_to_enable && !RW_n && !LDS_n ? 1'b0 : 1'b1;
+wire WE_BANK1_ODD_n_comb = second_4MB_access && safe_to_enable && !RW_n && !LDS_n ? 1'b0 : 1'b1;
 
-wire WE_BANK0_EVEN_n_comb = first_4MB_access && !RW_n && !UDS_n ? 1'b0 : 1'b1;
-wire WE_BANK1_EVEN_n_comb = second_4MB_access && !RW_n && !UDS_n ? 1'b0 : 1'b1;
+wire WE_BANK0_EVEN_n_comb = first_4MB_access && safe_to_enable && !RW_n && !UDS_n ? 1'b0 : 1'b1;
+wire WE_BANK1_EVEN_n_comb = second_4MB_access && safe_to_enable && !RW_n && !UDS_n ? 1'b0 : 1'b1;
 
 //=============================================================================
 // Output Mux: Registered at turbo, Combinatorial at 7 MHz
@@ -120,20 +130,21 @@ assign WE_BANK1_EVEN_n = CPU_SPEED_SWITCH ? WE_BANK1_EVEN_n_reg : WE_BANK1_EVEN_
 // DTACK Generation
 //=============================================================================
 
-reg [2:0] wait_counter;
-wire [2:0] wait_states = CPU_SPEED_SWITCH ? 3'd0 : 3'd0;
+reg [3:0] wait_counter;
+// DMA: 6 wait states for expansion card stability. CPU: 0 wait states.
+wire [3:0] wait_states = (!BGACK_n) ? 4'd6 : 4'd0;
 
-always @(posedge CLKCPU or posedge AS_CPU_n) begin
+always @(posedge CLKCPU) begin
 
-    if (AS_CPU_n) begin
+    if (AS_n) begin
         DTACK_n <= 1'b1;
-        wait_counter <= 3'd0;
+        wait_counter <= 4'd0;
     end else begin
 
         if (RAM_ACCESS) begin
             if (wait_counter < wait_states) begin
                 DTACK_n <= 1'b1;
-                wait_counter <= wait_counter + 3'd1;
+                wait_counter <= wait_counter + 4'd1;
             end else begin
                 DTACK_n <= 1'b0;
             end

--- a/rtl/flash.v
+++ b/rtl/flash.v
@@ -27,7 +27,7 @@ assign FLASH_ACCESS = A[23:20] == 4'hA     && !maprom_enabled               || /
                       A[23:19] == 5'b11111 &&  maprom_enabled               || // $F80000-FFFFFF
                       A[23:19] == 5'b11100 &&  maprom_enabled;                 // $E00000-E7FFFF
 
-always @(posedge CLKCPU or posedge AS_CPU_n) begin
+always @(posedge CLKCPU) begin
 
     if (AS_CPU_n) begin
         DTACK_n <= 1'b1;

--- a/rtl/main_top.v
+++ b/rtl/main_top.v
@@ -6,14 +6,16 @@ module main_top(
     input wire JP2,
     input wire JP3,           // Flash ROM Kickstart overlay enable
     input wire JP4,
-    input wire pll_inst1_CLKOUT0,  // 80 MHz from PLL (for turbo clock)
-    input wire pll_inst1_CLKOUT1,  // 100 MHz from PLL
+    input wire pll_inst1_CLKOUT0,  // 80 MHz from PLL (unused)
+    input wire pll_inst1_CLKOUT1,  // 100 MHz from PLL (turbo clock + C100M)
     input wire C7M_n,
     input wire RESET_n,
     input wire AS_CPU_n,
     input wire VPA_n,
     input wire [2:0] FC,
-    input wire DTACK_MB_n,
+    input wire DTACK_MB_n_IN,
+    output wire DTACK_MB_n_OUT,
+    output wire DTACK_MB_n_OE,
     input wire E_IN,
     input wire AS_MB_n_IN,
     
@@ -67,7 +69,7 @@ module main_top(
     output wire FLASH_A19,
     output wire FLASH_WE_n,
     output wire FLASH_OE_n,
-    output wire INT2_n,
+    input wire INT2_n,
     output wire E_OE
 );
 
@@ -101,29 +103,58 @@ wire ram_access;
 wire flash_access;
 
 // SD card access detection
-wire sdcard_access = !sd_configured_n && (A[23:16] == base_sd) && !AS_CPU_n;
+wire sdcard_access = !sd_configured_n && (A[23:16] == base_sd) && !AS_CPU_n && bgack_sync2;
 
-// Combined signals
-wire as_n = BG_68SEC000_n ? AS_CPU_n : AS_MB_n_IN;
+// BGACK_n synchronization — raw BGACK_n glitches can corrupt the as_n mux
+// and downstream DTACK logic. 2-stage C100M sync for all consumers.
+reg bgack_sync1, bgack_sync2;
+always @(posedge C100M) begin
+    bgack_sync1 <= BGACK_n;
+    bgack_sync2 <= bgack_sync1;
+end
+
+// 2-stage CLKCPU re-sync of bgack_sync2 (C100M -> CLKCPU CDC).
+reg bgack_cpu_s1, bgack_cpu;
+always @(posedge CLKCPU) begin
+    bgack_cpu_s1 <= bgack_sync2;
+    bgack_cpu <= bgack_cpu_s1;
+end
+
+// Select AS source by bus ownership (BGACK), not bus grant (BG).
+// BG can deassert while the DMA master still holds BGACK.
+wire as_n = bgack_sync2 ? AS_CPU_n : AS_MB_n_IN;
 wire ds_n = LDS_n & UDS_n;
 
 // AS control - don't drive AS to motherboard when accessing local RAM, SD card, or Flash
 wire as_mobo_n = AS_CPU_n | ram_access | sdcard_access | flash_access;
 
 //=============================================================================
-// Turbo Mode - Clock Generation (40 MHz from 80 MHz PLL)
+// Turbo Mode - Tunable Timing Parameters
+//=============================================================================
+// These parameters control expansion bus timing in turbo mode.
+// Adjust these values for hardware tuning without changing logic.
+
+localparam [3:0] PRECHARGE_TICKS = 4'd7;         // Minimum gap between bus cycles (25MHz ticks, 280ns)
+localparam [2:0] SETUP_TICKS = 3'd3;             // Minimum address setup time (25MHz ticks, 120ns)
+localparam [3:0] EXPANSION_DTACK_TICKS = 4'd12;  // Consecutive C100M samples of DTACK LOW before asserting (120ns)
+
+//=============================================================================
+// Turbo Mode - Clock Generation (25 MHz from 100 MHz PLL)
 //=============================================================================
 
+reg turbo_clk_pre;
 reg turbo_clk;
-always @ (posedge pll_inst1_CLKOUT0) begin
-    turbo_clk <= ~turbo_clk;  // Divide by 2: 80 MHz → 40 MHz
+always @ (posedge pll_inst1_CLKOUT1) begin
+    turbo_clk_pre <= ~turbo_clk_pre;  // 100 MHz → 50 MHz intermediate
+    if (turbo_clk_pre)
+        turbo_clk <= ~turbo_clk;      // 50 MHz → 25 MHz
 end
 
 //=============================================================================
 // CPU Speed Switch with Debouncing
 //=============================================================================
 
-localparam BOOT_7M_LIMIT = 30'd300000000;   // 3 seconds at 100 MHz
+localparam BOOT_7M_LIMIT = 30'd500000000;   // 5 seconds at 100 MHz
 reg [29:0] b_count;                         // boot on 7 MHz counter
 
 localparam DEBOUNCE_LIMIT = 21'd2000000;    // 20 ms at 100 MHz
@@ -174,32 +205,60 @@ always @(negedge RESET_n or posedge C100M) begin
 end
 
 //=============================================================================
-// Motherboard Synchronization (1-Stage C7M + Async AS_CPU_n Reset)
+// Motherboard Synchronization (C7M domain)
 //=============================================================================
 
 reg mobo_as_n = 1'b1;
 reg mobo_dtack_n = 1'b1;
 
-always @(negedge RESET_n or posedge C7M or posedge AS_CPU_n) begin
+// Safety counters (CLKCPU domain)
+// p_cnt: precharge — enforces minimum gap between bus cycles
+// s_cnt: setup — enforces minimum address valid time
+reg [3:0] p_cnt;
+reg [2:0] s_cnt;
+reg last_as_cpu;
 
+always @(posedge CLKCPU) begin
+    last_as_cpu <= AS_CPU_n;
+    
+    // Precharge Counter (Reset when AS High)
+    if (AS_CPU_n && !last_as_cpu) begin
+        p_cnt <= PRECHARGE_TICKS;
+    end else if (p_cnt != 0) begin
+        p_cnt <= p_cnt - 4'd1;
+    end
+    
+    // Address Setup Counter (Starts counting when AS_CPU_n goes Low)
+    // Address is valid when AS_CPU_n is Low.
+    if (AS_CPU_n) begin
+        s_cnt <= 3'd0;
+    end else begin
+        if (s_cnt <= SETUP_TICKS) begin
+             s_cnt <= s_cnt + 3'd1;
+        end
+    end
+end
+
+wire safety_ok = (p_cnt == 0) && (s_cnt >= SETUP_TICKS);
+
+// C7M-synchronous gate. Instant AS termination via combinatorial OR at AS_MB_n_OUT.
+// mobo_dtack_n provides C7M-filtered DTACK for 7MHz bypass and turbo legacy access.
+always @(posedge C7M or negedge RESET_n) begin
     if (!RESET_n) begin
-
         mobo_as_n <= 1'b1;
         mobo_dtack_n <= 1'b1;
-
+    end else if (AS_CPU_n) begin
+        mobo_as_n <= 1'b1;
+        mobo_dtack_n <= 1'b1;
     end else begin
-
-        if (AS_CPU_n) begin
-
+        if (cpu_speed_switch && !safety_ok)
             mobo_as_n <= 1'b1;
-            mobo_dtack_n <= 1'b1;
-
-        end else begin
-
+        else
             mobo_as_n <= as_mobo_n;
-            mobo_dtack_n <= DTACK_MB_n;
-
-        end
+        if (!mobo_as_n)
+            mobo_dtack_n <= DTACK_MB_n_IN;
+        else
+            mobo_dtack_n <= 1'b1;
     end
 end
 
@@ -210,13 +269,134 @@ end
 // Clock selection (hot-switchable)
 assign CLKCPU = cpu_speed_switch ? turbo_clk : C7M;
 
-// DTACK from motherboard (synchronized when in turbo)
-wire dtack_mobo_n = cpu_speed_switch ? mobo_dtack_n : DTACK_MB_n;
-assign DTACK_CPU_n = dtack_mobo_n & m6800_dtack_n & ram_dtack_n & sdcard_dtack_n & flash_dtack_n;
+// ----------------------------------------------------------------------------
+// Selective DTACK Timing
+// ----------------------------------------------------------------------------
 
-// AS to motherboard (synchronized when in turbo)
-assign AS_MB_n_OUT = cpu_speed_switch ? mobo_as_n : as_mobo_n;
-assign AS_MB_n_OE = BG_68SEC000_n | !AS_CPU_n;  // Keep driving until cycle completes
+// Address decoding: legacy devices use C7M DTACK path + armed gate,
+// expansion devices use C100M oversampled DTACK counter.
+wire is_chip_ram = (A[23:21] == 3'b000); // 000000-1FFFFF
+wire is_cia      = (A[23:16] == 8'hBF);
+wire is_custom   = (A[23:16] == 8'hDF);
+wire is_kickstart = (A[23:16] >= 8'hF0); // F00000-FFFFFF
+wire is_autoconfig = (A[23:16] == 8'hE8); // Autoconfig Space (0xE8xxxx)
+
+wire is_legacy_access = is_chip_ram | is_cia | is_custom | is_kickstart | is_autoconfig;
+
+// turbo_as_gate: blocks AS/DTACK until address setup + precharge are met
+wire turbo_as_gate = mobo_as_n | AS_CPU_n | (cpu_speed_switch & !safety_ok);
+
+// ----------------------------------------------------------------------------
+// Expansion DTACK — C100M Pause-on-Noise Counter
+// ----------------------------------------------------------------------------
+// Requires DTACK_MB_n_IN to be sampled LOW for EXPANSION_DTACK_TICKS consecutive
+// C100M cycles (120ns) before asserting mobo_dtack_n_fine. Noise glitches HIGH
+// PAUSE the counter but do NOT reset it — genuine DTACK eventually accumulates.
+// This gives far better noise immunity than a single C7M sample while keeping
+// total latency bounded (~120ns counter + CLKCPU retime).
+//
+// Reset via turbo_as_gate synced to C100M. The counter only runs after AS is
+// on the bus (safety_ok met, mobo_as_n LOW) — so stale DTACK from prior cycles
+// or safety-countdown noise can't accumulate ticks prematurely.
+reg turbo_gate_c100m_s1, turbo_gate_c100m_s2;
+always @(posedge C100M) begin
+    turbo_gate_c100m_s1 <= turbo_as_gate;
+    turbo_gate_c100m_s2 <= turbo_gate_c100m_s1;
+end
+
+reg [3:0] dtack_cnt;
+reg mobo_dtack_n_fine;
+reg dtack_s1, dtack_s2;
+
+always @(posedge C100M) begin
+    if (turbo_gate_c100m_s2) begin
+        dtack_cnt <= 4'd0;
+        mobo_dtack_n_fine <= 1'b1;
+        dtack_s1 <= 1'b1;
+        dtack_s2 <= 1'b1;
+    end else begin
+        dtack_s1 <= DTACK_MB_n_IN;
+        dtack_s2 <= dtack_s1;
+        // Counter: only increments when DTACK is actively LOW.
+        // When dtack_s2 goes HIGH (noise/glitch), counter PAUSES but
+        // does NOT reset. Prevents noise from restarting the count
+        // while still requiring genuine DTACK assertion.
+        if (!dtack_s2) begin
+            if (dtack_cnt < EXPANSION_DTACK_TICKS) begin
+                dtack_cnt <= dtack_cnt + 1'b1;
+                mobo_dtack_n_fine <= 1'b1;
+            end else begin
+                mobo_dtack_n_fine <= 1'b0;
+            end
+        end
+    end
+end
+
+// CLKCPU CDC sync — mobo_dtack_n_fine transitions on C100M edges, CLKCPU is
+// async to C100M. 2-stage sync for metastability protection. AS_CPU_n gate
+// prevents stale values from leaking across cycle boundaries.
+reg exp_dtack_sync1, exp_dtack_synced;
+always @(posedge CLKCPU) begin
+    if (AS_CPU_n) begin
+        exp_dtack_sync1 <= 1'b1;
+        exp_dtack_synced <= 1'b1;
+    end else begin
+        exp_dtack_sync1 <= mobo_dtack_n_fine;
+        exp_dtack_synced <= exp_dtack_sync1;
+    end
+end
+
+// CLKCPU-domain synchronizer: detect when physical DTACK has been released HIGH
+// Only used for edge detection (noise-tolerant), not for the DTACK value itself.
+reg legacy_dtack_sync1, legacy_dtack_sync2;
+always @(posedge CLKCPU) begin
+    legacy_dtack_sync1 <= DTACK_MB_n_IN;
+    legacy_dtack_sync2 <= legacy_dtack_sync1;
+end
+
+// Armed gate: latches HIGH once DTACK has been confirmed HIGH for 6 consecutive
+// CLKCPU samples (after 2-stage sync). Requires ~320ns of genuine HIGH from
+// physical pin — rejects noise/ringing that briefly crosses VIH.
+// Resets when AS_CPU_n goes HIGH (between cycles).
+reg [2:0] dtack_high_cnt;
+reg legacy_dtack_armed;
+always @(posedge CLKCPU) begin
+    if (AS_CPU_n) begin
+        dtack_high_cnt <= 3'd0;
+        legacy_dtack_armed <= 1'b0;
+    end else if (!legacy_dtack_armed) begin
+        if (legacy_dtack_sync2) begin
+            if (dtack_high_cnt == 3'd5)
+                legacy_dtack_armed <= 1'b1;
+            else
+                dtack_high_cnt <= dtack_high_cnt + 1'b1;
+        end else begin
+            dtack_high_cnt <= 3'd0;  // reset on any LOW — must be consecutive
+        end
+    end
+end
+
+// Turbo DTACK path selection:
+// Legacy: mobo_dtack_n + m6800_dtack_n + turbo_as_gate + armed gate.
+// Expansion: exp_dtack_synced + turbo_as_gate (C100M counter provides noise immunity).
+// Armed gate is legacy-only — expansion devices respond before it can arm.
+wire turbo_dtack_src = is_legacy_access ?
+    ((mobo_dtack_n & m6800_dtack_n) | turbo_as_gate | !legacy_dtack_armed) :
+    (exp_dtack_synced | turbo_as_gate);
+
+wire dtack_mobo_n = cpu_speed_switch ? turbo_dtack_src : DTACK_MB_n_IN;
+
+// In turbo mode, m6800_dtack_n is already gated inside turbo_dtack_src.
+// In 7MHz mode, it must still be AND'd directly.
+wire dtack_combined_n = dtack_mobo_n & (cpu_speed_switch ? 1'b1 : m6800_dtack_n) & ram_dtack_n & sdcard_dtack_n & flash_dtack_n;
+
+assign DTACK_CPU_n = dtack_combined_n;
+
+// AS to motherboard: turbo_as_gate in turbo mode (safety-gated), raw in 7MHz.
+assign AS_MB_n_OUT = cpu_speed_switch ? turbo_as_gate : as_mobo_n;
+// Tri-state AS during DMA (BGACK LOW). Uses bgack_sync2 — raw BGACK_n
+// glitches can tri-state AS mid-cycle, hanging expansion cards.
+assign AS_MB_n_OE = (BG_68SEC000_n | !AS_CPU_n) & bgack_sync2;
 
 // Data bus - autoconfig or SD card
 assign D_OUT = ac_data_oe ? {ac_data_out, 12'd0} : sd_data_out;
@@ -315,7 +495,8 @@ autoconfig_zii autoconfig(
 
 fastram ramcontrol(
     .CLKCPU(CLKCPU),
-    .CPU_SPEED_SWITCH(cpu_speed_switch),
+    .BGACK_n(bgack_sync2),
+    .CPU_SPEED_SWITCH(cpu_speed_switch && bgack_sync2), // Force 7MHz mode during DMA (BGACK_n=0)
     .A(A[23:21]),
     .JP4(JP4),
     .RW_n(RW_n),
@@ -356,7 +537,7 @@ sdcard sdcontrol(
     .MISO(SD_MISO),
     .CD_n(SD_CD_n),
     .DATA_OE(sd_data_oe),
-    .INT2_n(INT2_n),
+    .INT2_n(),                  // Directly active on bus — must not drive
     .SS_n(SD_SS_n),
     .SCLK(SD_SCLK),
     .MOSI(SD_MOSI),
@@ -383,5 +564,18 @@ flash romoverlay(
     .FLASH_OE_n(FLASH_OE_n),
     .DTACK_n(flash_dtack_n)
 );
+
+// ----------------------------------------------------------------------------
+// Bidirectional DTACK Drive (DMA to FastRAM)
+// ----------------------------------------------------------------------------
+// Drive DTACK_MB_n LOW when a DMA master accesses FPGA fast RAM.
+// Synchronous OE register + combinatorial AS gate for instant release.
+reg dtack_oe_reg;
+always @(posedge CLKCPU) begin
+    dtack_oe_reg <= (!bgack_cpu && ram_access && !ram_dtack_n);
+end
+
+assign DTACK_MB_n_OUT = 1'b0;
+assign DTACK_MB_n_OE = dtack_oe_reg & !as_n;
 
 endmodule

--- a/rtl/sdcard.v
+++ b/rtl/sdcard.v
@@ -122,6 +122,7 @@ wire [15:0] int_act = int_req & int_ena;
 
 wire any_int_act = |int_act;
 
+// INT2_n driver (Internal use only, not driving pin)
 assign INT2_n = !(any_int_act);
 
 always @(posedge C100M) begin


### PR DESCRIPTION
Complete rewrite of turbo mode timing and bus arbitration to support expansion cards (GVP HC+8 SCSI/RAM) alongside SF2000 fast RAM at 25MHz.

Key fixes:
- Synchronize BGACK_n (2-stage C100M) to prevent AS tri-state glitches during DMA transitions that hung expansion cards
- C100M oversampled DTACK counter (12-tick pause-on-noise) for expansion cards; C7M path with armed gate for legacy chipset
- Safety countdown (280ns precharge + 120ns setup) between bus cycles to let DTACK RC pullup clear on loaded Zorro bus
- Bidirectional DTACK_MB_n drive for DMA access to FPGA fast RAM
- Eliminate all async resets (posedge AS_n) to fix metastability hangs
- Reduce turbo clock 40MHz -> 25MHz (68SEC000 rated 20MHz)
- SDC constraints for turbo_clk, CDC clock groups, autoconfig false paths
- Bus arbiter CDC: synchronize BG_68SEC000_n (25MHz -> C7M crossing)
- DMA address glitch filter in fastram prevents SRAM bus contention
- INT2_n changed from output to input to avoid interrupt bus contention
- IO drive strength increased to maximum on all bus-facing outputs

Tested stable: GVP SCSI boot, file copy, SysInfo drive test/stresstest, SF2000 4MB + GVP 4MB RAM coexistence, Frontier 3h30m+ from floppy.